### PR TITLE
Fix renderTokenHUD rendering by wrapping plain HTML with jQuery

### DIFF
--- a/classes/TokenColorMarker.mjs
+++ b/classes/TokenColorMarker.mjs
@@ -38,14 +38,14 @@ export class TokenColorMarker {
             }
 
             // Add the UI
-            this.addTokenColorMarkerUI(app, html, data);
+            this.addTokenColorMarkerUI(app, $(html), data);
 
             // register click event listener for token color marker button
-            html.on('click', `.control-icon[data-action="${MODULENAME}"]`, (event) => {
+            $(html).on('click', `.control-icon[data-action="${MODULENAME}"]`, (event) => {
                 this.activateTokenColorMarkerButton($(event.currentTarget), app);
             });
 
-            let palette = html.find(`.${MODULENAME}-palette`);
+            let palette = $(html).find(`.${MODULENAME}-palette`);
 
             // register click event listener for token color marker palette icons
             palette.on('click', `.${MODULENAME}`, (event) => {
@@ -58,7 +58,7 @@ export class TokenColorMarker {
             });
 
             // register click event listener for effects button
-            html.on('click', '.control-icon[data-action="effects"]', (event) => {
+            $(html).on('click', '.control-icon[data-action="effects"]', (event) => {
                 this.deactivateTokenColorMarkerButton($(event.currentTarget));
             });
 


### PR DESCRIPTION
This PR fixes a change I assume made by Foundry VTT where hooks are passed plain HTML instead of a jQuery object.

To fix with minimal changes I have just wrapped the few places at the highest level where jQuery methods are invoked, and to pass it as jQuery downstream.

Tested locally on Foundry Release 13.342 with the Powered by the Apocalypse system.

Thanks for the great module.